### PR TITLE
Allow non-scalar arguments to atan2 when dimensions match

### DIFF
--- a/src/Data/Quantity/Math.purs
+++ b/src/Data/Quantity/Math.purs
@@ -50,10 +50,7 @@ lift ∷ (Decimal → Decimal) → Quantity → Result
 lift fn q = (scalar' <<< fn) <$> toScalar' q
 
 lift2 ∷ (Decimal → Decimal → Decimal) → Quantity → Quantity → Result
-lift2 fn q1 q2 = scalar' <$> (fn <$> toScalar' q1 <*> toScalar' q2)
-
-lift2' ∷ (Decimal → Decimal → Decimal) → Quantity → Quantity → Result
-lift2' f q1 q2 = do
+lift2 f q1 q2 = do
   let u = derivedUnit q1
   v1 ← q1 `asValueIn'` u
   v2 ← q2 `asValueIn'` u
@@ -69,7 +66,7 @@ atan ∷ Quantity → Result
 atan = lift Decimal.atan
 
 atan2 ∷ Quantity → Quantity → Result
-atan2 = lift2' Decimal.atan2
+atan2 = lift2 Decimal.atan2
 
 cos ∷ Quantity → Result
 cos = lift Decimal.cos
@@ -114,13 +111,13 @@ log10 ∷ Quantity → Result
 log10 = lift Decimal.log10
 
 max2 ∷ Quantity → Quantity → Result
-max2 = lift2' Decimal.max
+max2 = lift2 Decimal.max
 
 max ∷ NonEmptyList Quantity → Result
 max xs = foldM max2 (head xs) (tail xs)
 
 min2 ∷ Quantity → Quantity → Result
-min2 = lift2' Decimal.min
+min2 = lift2 Decimal.min
 
 min ∷ NonEmptyList Quantity → Result
 min xs = foldM min2 (head xs) (tail xs)
@@ -131,7 +128,7 @@ mean xs = (_ ⊘ n) <$> foldM (⊕) (head xs) (tail xs)
     n = scalar' (Decimal.fromInt (length xs))
 
 modulo ∷ Quantity → Quantity → Result
-modulo = lift2' Decimal.modulo
+modulo = lift2 Decimal.modulo
 
 round ∷ Quantity → Result
 round = lift Decimal.round

--- a/src/Data/Quantity/Math.purs
+++ b/src/Data/Quantity/Math.purs
@@ -52,6 +52,13 @@ lift fn q = (scalar' <<< fn) <$> toScalar' q
 lift2 ∷ (Decimal → Decimal → Decimal) → Quantity → Quantity → Result
 lift2 fn q1 q2 = scalar' <$> (fn <$> toScalar' q1 <*> toScalar' q2)
 
+lift2' ∷ (Decimal → Decimal → Decimal) → Quantity → Quantity → Result
+lift2' f q1 q2 = do
+  let u = derivedUnit q1
+  v1 ← q1 `asValueIn'` u
+  v2 ← q2 `asValueIn'` u
+  pure $ quantity' (f v1 v2) u
+
 acos ∷ Quantity → Result
 acos = lift Decimal.acos
 
@@ -62,7 +69,7 @@ atan ∷ Quantity → Result
 atan = lift Decimal.atan
 
 atan2 ∷ Quantity → Quantity → Result
-atan2 = lift2 Decimal.atan2
+atan2 = lift2' Decimal.atan2
 
 cos ∷ Quantity → Result
 cos = lift Decimal.cos
@@ -107,25 +114,13 @@ log10 ∷ Quantity → Result
 log10 = lift Decimal.log10
 
 max2 ∷ Quantity → Quantity → Result
-max2 q1 q2 = do
-  let u1 = derivedUnit q1
-  v1 ← q1 `asValueIn'` u1
-  v2 ← q2 `asValueIn'` u1
-  if v1 >= v2
-    then pure q1
-    else pure q2
+max2 = lift2' Decimal.max
 
 max ∷ NonEmptyList Quantity → Result
 max xs = foldM max2 (head xs) (tail xs)
 
 min2 ∷ Quantity → Quantity → Result
-min2 q1 q2 = do
-  let u1 = derivedUnit q1
-  v1 ← q1 `asValueIn'` u1
-  v2 ← q2 `asValueIn'` u1
-  if v1 <= v2
-    then pure q1
-    else pure q2
+min2 = lift2' Decimal.min
 
 min ∷ NonEmptyList Quantity → Result
 min xs = foldM min2 (head xs) (tail xs)
@@ -136,12 +131,7 @@ mean xs = (_ ⊘ n) <$> foldM (⊕) (head xs) (tail xs)
     n = scalar' (Decimal.fromInt (length xs))
 
 modulo ∷ Quantity → Quantity → Result
-modulo q1 q2 = do
-  let u = derivedUnit q1
-  v1 ← q1 `asValueIn'` u
-  v2 ← q2 `asValueIn'` u
-  let res = v1 `Decimal.modulo` v2
-  pure (quantity' res u)
+modulo = lift2' Decimal.modulo
 
 round ∷ Quantity → Result
 round = lift Decimal.round


### PR DESCRIPTION
Fix atan2 to allow arguments with the same dimensions and remove duplicate code.