### PR TITLE
Fix warning about unspecified imports

### DIFF
--- a/src/Quantities.purs
+++ b/src/Quantities.purs
@@ -17,18 +17,35 @@ module Quantities
   , module DUB
   ) where
 
-import Data.Quantity as DQ
-import Data.Quantity.Math as DQM
-import Data.Quantity.Physics as DQP
-import Data.Units as DU
-import Data.Units.SI as DUS
-import Data.Units.SI.Derived as DUSD
-import Data.Units.SI.Accepted as DUSA
-import Data.Units.Time as DUT
-import Data.Units.Imperial as DUI
-import Data.Units.USCustomary as DUUSC
-import Data.Units.Astronomical as DUA
-import Data.Units.Currency as DUC
-import Data.Units.Misc as DUM
-import Data.Units.CGS as DUCGS
-import Data.Units.Bit as DUB
+import Data.Quantity (ConversionError(..), Quantity, abs, approximatelyEqual, asValueIn,
+                      asValueIn', convert, convertTo, derivedUnit, errorMessage, fullSimplify,
+                      isFinite, pow, prettyPrint, prettyPrint', qAdd, qDivide, qMultiply,
+                      qNegate, qSubtract, quantity, quantity', scalar, scalar', showResult,
+                      sqrt, toScalar, toScalar', toStandard, (.*), (⊕), (⊖), (⊗), (⊘)) as DQ
+import Data.Quantity.Math (acos, acosh, asin, asinh, atan, atan2, atanh, ceil, cos, cosh, e,
+                           exp, factorial, floor, gamma, ln, log10, max, max2, mean, min,
+                           min2, modulo, pi, round, sin, sinh, tan, tanh, tau) as DQM
+import Data.Quantity.Physics (avogadroConstant, electronCharge, electronMass, g0,
+                              gravitationalConstant, kB, planckConstant, protonMass,
+                              speedOfLight, µ0, µB, α, ε0, ℏ) as DQP
+import Data.Units (DerivedUnit, Prefix, atto, baseRepresentation, binaryPrefix, centi, deci,
+                   decimalPrefix, divideUnits, exa, exbi, femto, gibi, giga, hecto, kibi,
+                   kilo, makeNonStandard, makeStandard, mebi, mega, micro, milli, nano, pebi,
+                   peta, pico, power, prefixName, removePrefix, simplify, splitByDimension,
+                   tebi, tera, toStandardUnit, toString, unity, yobi, zebi, (./), (.^)) as DU
+import Data.Units.SI (ampere, candela, gram, kelvin, kilogram, meter, mole, second) as DUS
+import Data.Units.SI.Derived (becquerel, coulomb, farad, gray, henry, hertz, joule, katal,
+                              lumen, lux, newton, ohm, pascal, radian, siemens, sievert,
+                              steradian, tesla, volt, watt, weber) as DUSD
+import Data.Units.SI.Accepted (angstrom, astronomicalUnit, bar, barn, bel, degree,
+                               electronvolt, hectare, liter, tonne) as DUSA
+import Data.Units.Time (day, hour, minute, month, week, year) as DUT
+import Data.Units.Imperial (foot, furlong, inch, mile, ounce, pound, yard) as DUI
+import Data.Units.USCustomary (cup, fluidounce, gallon, hogshead,
+                               pint, rod, tablespoon, teaspoon) as DUUSC
+import Data.Units.Astronomical (lightyear, parsec) as DUA
+import Data.Units.Currency (dollar, euro) as DUC
+import Data.Units.Misc (atm, btu, calorie, dot, fortnight, lbf,
+                        mmHg, person, piece, pixel, psi, rpm) as DUM
+import Data.Units.CGS (gauss) as DUCGS
+import Data.Units.Bit (bit, byte) as DUB


### PR DESCRIPTION
I should have fixed this in the last PR... Anyways, the warning were like this one:
```
Module Data.Units.SI was imported as DUS with unspecified imports.
    As this module is being re-exported, consider using the explicit form:

      import Data.Units.SI (ampere, candela, gram, kelvin, kilogram, meter, mole, second) as DUS
```

So I made all imports explicit. It's not pretty, but I think there's no other way of getting rid of the warnings. The proper solution would be https://github.com/purescript/purescript/issues/2478 but it was never implemented.