### PR TITLE
Add the golden ratio φ

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "purescript-foldable-traversable": "^4.1.0",
     "purescript-numbers": "^7.0.0",
     "purescript-pairs": "^7.0.0",
-    "purescript-decimals": "^5.0.0"
+    "purescript-decimals": "^5.0.0",
+    "purescript-math": "git://github.com/brianrodri/purescript-math#add-phi"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",

--- a/bower.json
+++ b/bower.json
@@ -21,8 +21,7 @@
     "purescript-foldable-traversable": "^4.1.0",
     "purescript-numbers": "^7.0.0",
     "purescript-pairs": "^7.0.0",
-    "purescript-decimals": "^5.0.0",
-    "purescript-math": "git://github.com/brianrodri/purescript-math#add-phi"
+    "purescript-decimals": "^5.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",

--- a/src/Data/Quantity/Math.purs
+++ b/src/Data/Quantity/Math.purs
@@ -33,6 +33,7 @@ module Data.Quantity.Math
   , pi
   , e
   , tau
+  , phi
   ) where
 
 import Prelude
@@ -149,3 +150,6 @@ e = scalar' Decimal.e
 
 tau ∷ Quantity
 tau = scalar' $ Decimal.fromNumber 2.0 * Decimal.pi
+
+phi ∷ Quantity
+phi = scalar' Decimal.phi

--- a/src/Data/Quantity/Math.purs
+++ b/src/Data/Quantity/Math.purs
@@ -152,4 +152,4 @@ tau ∷ Quantity
 tau = scalar' $ Decimal.fromNumber 2.0 * Decimal.pi
 
 phi ∷ Quantity
-phi = scalar' Decimal.phi
+phi = (1.0 + (5.0 .^ 0.5)) ./ (2.0)

--- a/src/Quantities.purs
+++ b/src/Quantities.purs
@@ -26,7 +26,7 @@ import Data.Quantity (ConversionError(..), Quantity, abs, approximatelyEqual, as
                       sqrt, toScalar, toScalar', toStandard, (.*), (⊕), (⊖), (⊗), (⊘)) as DQ
 import Data.Quantity.Math (acos, acosh, asin, asinh, atan, atan2, atanh, ceil, cos, cosh, e,
                            exp, factorial, floor, gamma, ln, log10, max, max2, mean, min,
-                           min2, modulo, pi, round, sin, sinh, tan, tanh, tau) as DQM
+                           min2, modulo, pi, round, sin, sinh, tan, tanh, tau, phi) as DQM
 import Data.Quantity.Physics (avogadroConstant, electronCharge, electronMass, g0,
                               gravitationalConstant, kB, planckConstant, protonMass,
                               idealGasConstant, speedOfLight, µ0, µB, α, ε0, ℏ) as DQP


### PR DESCRIPTION
Adds the [golden ratio](https://en.wikipedia.org/wiki/Golden_ratio) phi as a new mathematical constant.
- Inspired by sharkdp/insect#246
- PR written using #176 as a template 