### PR TITLE
Add ounce-force/ozf force unit

### DIFF
--- a/src/Data/Units/Misc.purs
+++ b/src/Data/Units/Misc.purs
@@ -17,6 +17,10 @@ btu = makeNonStandard "BTU" "BTU" 1055055.85262 (gram <> meter .^ 2.0 <> second 
 lbf ∷ DerivedUnit
 lbf = makeNonStandard "pound_force" "lbf" 4448.222 (gram <> meter <> second .^ (-2.0))
 
+-- | Unit of force, *1 ozf = 16 lbf*.
+ozf ∷ DerivedUnit
+ozf = makeNonStandard "ounce_force" "ozf" (4448.222 / 16.0) (gram <> meter <> second .^ (-2.0))
+
 -- | Unit of force, *1 kgf = 9.806650 N*.
 kgf ∷ DerivedUnit
 kgf = makeNonStandard "pound_force" "kgf" 9806.650 (gram <> meter <> second .^ (-2.0))

--- a/src/Quantities.purs
+++ b/src/Quantities.purs
@@ -49,7 +49,7 @@ import Data.Units.USCustomary (cup, fluidounce, gallon, hogshead,
                                pint, rod, tablespoon, teaspoon) as DUUSC
 import Data.Units.Astronomical (lightyear, parsec) as DUA
 import Data.Units.Currency (dollar, euro) as DUC
-import Data.Units.Misc (atm, btu, calorie, dot, fortnight, frame, lbf,
+import Data.Units.Misc (atm, btu, calorie, dot, fortnight, frame, lbf, ozf,
                         mmHg, person, piece, pixel, psi, rpm) as DUM
 import Data.Units.CGS (gauss) as DUCGS
 import Data.Units.Bit (bit, byte) as DUB

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -28,7 +28,7 @@ import Data.Units.Nautical(knot, nauticalMile)
 import Data.Units.PartsPerX(percent, partsPerMillion, partsPerBillion, partsPerTrillion, partsPerQuadrillion)
 import Data.Units.CGS (gauss)
 import Data.Units.Astronomical (parsec, lightyear)
-import Data.Units.Misc (calorie, btu, lbf, rpm, fortnight, mmHg, psi, atm)
+import Data.Units.Misc (calorie, btu, lbf, ozf, rpm, fortnight, mmHg, psi, atm)
 import Data.Units.Bit (bit, byte)
 import Data.Quantity (Quantity, (.*), prettyPrint, (⊕), (⊖), (⊗), (⊘),
                       convertTo, asValueIn, pow, scalar, sqrt, derivedUnit,
@@ -597,6 +597,7 @@ main = runTest do
       equal (4.184 .* joule) (1.0 .* calorie)
       equal (1055.05585262 .* joule) (1.0 .* btu)
       equal (4.448222 .* newton) (1.0 .* lbf)
+      equal ((4.448222 / 16.0) .* newton) (1.0 .* ozf)
       almostEqual (1.0 .* hertz) (60.0 .* rpm)
       equal (2.0 .* week) (1.0 .* fortnight)
       equal (133.322387415 .* pascal) (1.0 .* mmHg)


### PR DESCRIPTION
This unit is extremely common in motor specifications in US when
specifying motor toque using the ambiguous form of `oz in`, it should
be `ozf in` to follow `lbf` for pound force.

I've found this unit so many times and struggled to convert it to something sane like `N m` or `N cm`.

Appreciate any comments as I've never written any Purescript.

Hopefully I should be able to run:

`1 ozf in -> N cm` now .